### PR TITLE
Fixed relation ordering

### DIFF
--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -199,7 +199,15 @@ class DataTables extends DataTablesQueryBuilders
      */
     public function searchable(... $searchkeys)
     {
-        $this->searchable = $searchkeys;
+        $last = [];
+        foreach($searchkeys as $key => $value){
+            if(str_contains($value, '.')){
+                $last[] = $value;
+            }else{
+                $this->searchable[] = $value;
+            }
+        }
+        $this->searchable = array_merge($this->searchable, $last);
         $this->hasSearchable = true;
         return $this;
     }

--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -199,15 +199,7 @@ class DataTables extends DataTablesQueryBuilders
      */
     public function searchable(... $searchkeys)
     {
-        $last = [];
-        foreach($searchkeys as $key => $value){
-            if(str_contains($value, '.')){
-                $last[] = $value;
-            }else{
-                $this->searchable[] = $value;
-            }
-        }
-        $this->searchable = array_merge($this->searchable, $last);
+        $this->searchable = $searchkeys;
         $this->hasSearchable = true;
         return $this;
     }
@@ -282,10 +274,15 @@ class DataTables extends DataTablesQueryBuilders
      */
     private function sortModel()
     {
-        if($this->hasSearchable){
-            $model = $this->model->orderBy($this->order['column'], $this->order['dir'])->skip($this->start)->take($this->length)->get();
+
+        $build = $this->hasSearchable ? $this->model->skip($this->start)->take($this->length) : $this->model;
+
+        $sortByRelation = str_contains($this->order['column'], '.');
+
+        if($sortByRelation){
+            $model = $this->order['dir'] === 'asc' ? $build->get()->sortBy($this->order['column']) : $build->get()->sortByDesc($this->order['column']);
         }else{
-            $model = $this->model->orderBy($this->order['column'], $this->order['dir'])->get();
+            $model = $build->orderBy($this->order['column'], $this->order['dir'])->get();
         }
 
         if($this->search && !$this->hasSearchable){


### PR DESCRIPTION
When sorting on a relation `user.roles` the key is `role.name`. This throws an error when using the mysql orderBy method. 

Using the sortBy method on relations fixes the problem