### PR TITLE
Remove Backticks for MS SQL Server compatibility

### DIFF
--- a/src/DataTables.php
+++ b/src/DataTables.php
@@ -334,9 +334,9 @@ class DataTables extends DataTablesQueryBuilders
             }
 
             if($index === 0){
-                $this->model = $this->model->whereRaw("lower(`$column`) LIKE ?", "%{$this->search['value']}%");
+                $this->model = $this->model->whereRaw("lower($column) LIKE ?", "%{$this->search['value']}%");
             }else{
-                $this->model = $this->model->orWhereRaw("lower(`$column`) LIKE ?", "%{$this->search['value']}%");
+                $this->model = $this->model->orWhereRaw("lower($column) LIKE ?", "%{$this->search['value']}%");
             }
             
         }
@@ -352,7 +352,7 @@ class DataTables extends DataTablesQueryBuilders
         $explode = explode('.', $column);
 
         $this->model = $this->model->orWhereHas($explode[0], function($query) use($explode){
-            $query->whereRaw("lower(`$explode[1]`) LIKE ?", "%{$this->search['value']}%");
+            $query->whereRaw("lower($explode[1]) LIKE ?", "%{$this->search['value']}%");
         });
         
     }


### PR DESCRIPTION
Backticks are not valid on MS SQL in the following statement: lower(`$column`).
Resolution: remove backticks

Tested on MS SQL Server 2012, MySQL 5.7.25